### PR TITLE
hidden.css: use --custom-app-top-bar-height to better hide the title bar

### DIFF
--- a/hidden.css
+++ b/hidden.css
@@ -2,7 +2,7 @@
   --custom-app-top-bar-height: 0 !important;
 
   div[class^="base_"] {
-    & > div[class^="bar_"] {
+    & > div.bar_c38106 {
       display: none;
     }
   }

--- a/hidden.css
+++ b/hidden.css
@@ -8,6 +8,6 @@
   }
 
   ul[data-list-id="guildsnav"] > div[class^="itemsContainer_"] {
-    margin-top: 8px;
+    margin-top: var(--vr-header-snippet-server-padding);
   }
 }

--- a/hidden.css
+++ b/hidden.css
@@ -7,7 +7,7 @@
     }
   }
 
-  ul[data-list-id="guildsnav"] > div[class^="itemsContainer_"] {
+  ul[data-list-id="guildsnav"] > div.itemsContainer_ef3116 {
     margin-top: var(--vr-header-snippet-server-padding);
   }
 }

--- a/hidden.css
+++ b/hidden.css
@@ -1,13 +1,13 @@
 .visual-refresh {
-    div[class^="base_"] {
-        grid-template-rows: auto;
+  --custom-app-top-bar-height: 0 !important;
 
-        & > div[class^="bar_"] {
-            display: none;
-        }
+  div[class^="base_"] {
+    & > div[class^="bar_"] {
+      display: none;
     }
+  }
 
-    ul[data-list-id="guildsnav"] > div.itemsContainer_ef3116 {
-        margin-top: 16px;
-    }
+  ul[data-list-id="guildsnav"] > div[class^="itemsContainer_"] {
+    margin-top: 8px;
+  }
 }

--- a/hidden.css
+++ b/hidden.css
@@ -1,7 +1,7 @@
 .visual-refresh {
   --custom-app-top-bar-height: 0 !important;
 
-  div[class^="base_"] {
+  div.base_c48ade {
     & > div.bar_c38106 {
       display: none;
     }


### PR DESCRIPTION
uses `--custom-app-top-bar-height` to set the height of the top bar to 0 instead of the grid template rows thing

fixes all the issues with this snippet (other than missing inbox ofc)

https://github.com/user-attachments/assets/edb3386b-4ae5-498a-b92d-a0faefa629cd

previously stuff like this would happen if the sidebar server list wasn't full

among some other issues like it being pretty broken on the friends list / dms

all looks perfect now:

![Screenshot from 25 03 26 16:22:36](https://github.com/user-attachments/assets/e63a6405-0f58-48cb-8d20-0c47486bdea1)
![Screenshot from 25 03 26 16:22:42](https://github.com/user-attachments/assets/33ead275-df3d-4fbb-a9a8-a4c363d50804)
