### PR TITLE
Fix unnecessary border radius for sidebar

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -50,6 +50,10 @@
 
         & > div[class*='content__'] {
             z-index: 0;
+			
+			& > div.sidebar__5e434 > div.sidebarListRounded__5e434 {
+				border-start-start-radius: 0 !important;
+			}
         }
 
         &:has(.threadSidebarOpen_f75fb0.threadSidebarFloating_f75fb0) > .bar_c38106 {

--- a/desktop.css
+++ b/desktop.css
@@ -64,6 +64,10 @@
 
         & > div[class*='content__'] {
             z-index: 0;
+			
+			& > div.sidebar__5e434 > div.sidebarListRounded__5e434 {
+				border-start-start-radius: 0 !important;
+			}
         }
 
         & > div.bar_c38106 {


### PR DESCRIPTION
# Description
Simple fix to remove the inconsistent border radius around the sidebar that is no longer necessary due to the top bar being removed. It's quite subtle but more noticeable with certain themes where the rounding looks out of place.

# Screenshots
Before:
<img width="708" height="70" alt="Before" src="https://github.com/user-attachments/assets/647d6dbb-c1ba-48c7-aa45-836007565b61" />
After:
<img width="708" height="70" alt="After" src="https://github.com/user-attachments/assets/9cab268e-773d-4ed3-b2c4-ffb7dbdccc53" />



